### PR TITLE
feat: greetingのモバイル強制改行、navラベルをPHOTOに、lightboxの余白を削除

### DIFF
--- a/src/app/(with-header)/_components/header-navigation.tsx
+++ b/src/app/(with-header)/_components/header-navigation.tsx
@@ -5,6 +5,13 @@ import { usePathname } from "next/navigation";
 
 const NAVIGATION_LINKS = ["photography", "blog", "about"] as const;
 
+// 表示名だけを短くする。遷移先は /photography のまま。
+const NAVIGATION_LABELS: Record<(typeof NAVIGATION_LINKS)[number], string> = {
+    photography: "PHOTO",
+    blog: "BLOG",
+    about: "ABOUT",
+};
+
 export const HeaderNavigation = () => {
     const pathname = usePathname();
 
@@ -23,7 +30,7 @@ export const HeaderNavigation = () => {
                         href={`/${link}`}
                         className="relative block pb-1 transition-colors hover:text-gray-900"
                     >
-                        {link.toUpperCase()}
+                        {NAVIGATION_LABELS[link]}
                         {isActive ? (
                             <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-sm bg-current" />
                         ) : null}

--- a/src/app/(with-header)/_components/navigation.tsx
+++ b/src/app/(with-header)/_components/navigation.tsx
@@ -11,6 +11,13 @@ import {
 
 const NAVIGATION_LINKS = ["photography", "blog", "about"] as const;
 
+// 表示名だけを短くする。遷移先は /photography のまま。
+const NAVIGATION_LABELS: Record<(typeof NAVIGATION_LINKS)[number], string> = {
+    photography: "PHOTO",
+    blog: "BLOG",
+    about: "ABOUT",
+};
+
 export const Navigation = () => {
     const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
     const [visibleCount, setVisibleCount] = useState(0);
@@ -64,7 +71,7 @@ export const Navigation = () => {
                     className="my-2 w-fit"
                 >
                     <Link href={`/${link}`} className="block">
-                        {link.toUpperCase()}
+                        {NAVIGATION_LABELS[link]}
                     </Link>
                 </motion.div>
             ))}

--- a/src/app/(with-header)/photography/_component/photo-gallery.tsx
+++ b/src/app/(with-header)/photography/_component/photo-gallery.tsx
@@ -100,7 +100,7 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
                 <Dialog.Portal>
                     <Dialog.Overlay className="fixed inset-0 z-50 bg-black/72 backdrop-blur-sm" />
                     <Dialog.Content
-                        className="fixed inset-0 z-50 flex items-center justify-center p-4 focus:outline-none"
+                        className="fixed inset-0 z-50 flex items-center justify-center focus:outline-none"
                         onPointerDown={() => {
                             setSelectedPhoto(null);
                         }}

--- a/src/app/_component/greeting-message.tsx
+++ b/src/app/_component/greeting-message.tsx
@@ -19,7 +19,7 @@ type GreetingMessageProps = {
 export const GreetingMessage = ({ greeting }: GreetingMessageProps) => (
     <h1
         aria-label={`${greeting}、${NAME_TEXT}`}
-        className="ml-[-4px] flex flex-wrap text-3xl font-medium sm:flex-nowrap"
+        className="ml-[-4px] flex flex-col items-start text-3xl font-medium sm:flex-row"
     >
         <AnimatedText text={`${greeting}、`} />
         <AnimatedText

--- a/src/components/molecules/menu-drawer.tsx
+++ b/src/components/molecules/menu-drawer.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 // ナビゲーションアイテムの定義
 const NAVIGATION_ITEMS = [
     {
-        name: "Photography",
+        name: "Photo",
         label: "写真作品",
         url: "/photography",
     },


### PR DESCRIPTION
## 変更内容

### 1. greeting の改行（`src/app/_component/greeting-message.tsx`）
`flex-wrap`（幅が足りないときだけ折り返す）から `flex-col sm:flex-row` に変更。
モバイル（sm 未満）では「こんばんは、」/「にこまるです」が常に2行になり、sm 以上は従来どおり1行。

### 2. ナビゲーションの表示名（`navigation.tsx` / `header-navigation.tsx` / `menu-drawer.tsx`）
表示ラベルを `PHOTOGRAPHY` → `PHOTO` に変更。
**遷移先の URL は `/photography` のまま**で、ルーティング（`app/(with-header)/photography`、`/api/photography/[photoId]`）には手を入れていません。

### 3. 拡大ダイアログの余白（`photography/_component/photo-gallery.tsx`）
`Dialog.Content` の `p-4` を削除し、画像がビューポート全体を使うように。
`object-contain` は維持しているので画像はトリミングされません。

## 確認

- `pnpm exec tsc --noEmit` : エラーなし
- `pnpm run check` : 新規の指摘なし（既存の `.vscode/settings.json` のパースエラーと既存 warning のみ）
- ローカル dev サーバーで実測
  - 390px 幅: greeting が2行（top 138 / 174）、ナビは `PHOTO -> /photography`
  - 1280px 幅: greeting は1行（両方 top 132）
- `/photography` ページはローカル D1 に `photos` テーブルがなく 500 になるため、拡大ダイアログの見た目はブラウザ確認できていません（変更は `p-4` の削除のみ）