### PR TITLE
fix: lightbox のゴーストクリック修正 / Preview URLs 有効化 / top 画像の優先読み込み

### DIFF
--- a/src/app/(with-header)/photography/_component/photo-gallery.tsx
+++ b/src/app/(with-header)/photography/_component/photo-gallery.tsx
@@ -101,7 +101,9 @@ export function PhotoGallery({ photos }: PhotoGalleryProps) {
                     <Dialog.Overlay className="fixed inset-0 z-50 bg-black/72 backdrop-blur-sm" />
                     <Dialog.Content
                         className="fixed inset-0 z-50 flex items-center justify-center focus:outline-none"
-                        onPointerDown={() => {
+                        // Closing on pointerdown lets the synthesized touch click
+                        // land on the gallery button underneath and reopen it.
+                        onClick={() => {
                             setSelectedPhoto(null);
                         }}
                     >

--- a/src/app/_component/bg-image.tsx
+++ b/src/app/_component/bg-image.tsx
@@ -6,18 +6,30 @@ type BgImageProps = {
 
 export const BgImage = ({ onLoaded }: BgImageProps) => {
     return (
-        <Image
-            src="/bg-image-1.webp"
-            blurDataURL={"/bg-image-1.webp"}
-            placeholder="blur"
-            alt="Background Image"
-            width={1920}
-            height={1080}
-            className="-z-50 object-cover select-none h-[100lvh] brightness-80 saturate-80 pointer-events-none object-[45%_43%] md:object-top"
-            priority
-            onLoad={() => {
-                onLoaded?.();
-            }}
-        />
+        <>
+            {/* head に巻き上げられ、フォントの preload より先に発火させる */}
+            <link
+                rel="preload"
+                as="image"
+                href="/bg-image-1.webp"
+                fetchPriority="high"
+            />
+            <Image
+                src="/bg-image-1.webp"
+                blurDataURL={"/bg-image-1.webp"}
+                placeholder="blur"
+                alt="Background Image"
+                width={1920}
+                height={1080}
+                className="-z-50 object-cover select-none h-[100lvh] brightness-80 saturate-80 pointer-events-none object-[45%_43%] md:object-top"
+                priority
+                // /_next/image は元ファイルへ 302 を返すだけなので、
+                // ファーストビューの画像に往復を1つ足さないよう直接読ませる
+                unoptimized
+                onLoad={() => {
+                    onLoaded?.();
+                }}
+            />
+        </>
     );
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,9 @@
     "observability": {
         "enabled": true
     },
+    // PR ごとの `wrangler versions upload`(.github/workflows/preview.yml)が返す
+    // <version>-nikomaru-vrc.<subdomain>.workers.dev を実際に配信させる
+    "preview_urls": true,
     // ISR / ページキャッシュのバックエンドとして Workers Cache を利用する
     "cache": {
         "enabled": true


### PR DESCRIPTION
## 1. fix: lightbox のゴーストクリック (`5449b3c`)

スマホでフォトの拡大表示中に余白をタップして閉じると、直後に別の画像が開いてしまう。

`Dialog.Content` を `onPointerDown` で閉じていたため、`touchstart` 時点でオーバーレイが消え、指を離したあとに合成される `click` が hit-test をやり直して真下のグリッドボタンに命中していた。`onClick` に変更してイベントをライトボックス自身が受け取るようにした。挙動は変更なし（画像タップでも閉じる、× ボタンも従来どおり）。

## 2. chore: Preview URLs を有効化 (`e8d601d`)

`preview_urls` はデフォルト `false` のため、`.github/workflows/preview.yml` が PR にコメントする `<version>-nikomaru-vrc.<subdomain>.workers.dev` が配信されていなかった。`wrangler.jsonc` で有効化（`dist/server/wrangler.json` にも伝播することを確認済み）。

Worker 単位の設定なので、main マージ後の `wrangler deploy` で初めて効く可能性あり。

## 3. perf: top の背景画像を最優先で読み込む (`8212fea`)

`next/image` 経由だと `/_next/image?...` が元ファイルへ 302 を返すだけで、ファーストビューの画像に往復が 1 つ増えていた。

- `unoptimized` で `/bg-image-1.webp` を直接読ませる
- `head` に `<link rel="preload" as="image" fetchPriority="high">` を出し、フォントの preload より先にリクエストさせる

検証（ローカル `wrangler dev` + 実ブラウザ）:
- head の preload がフォント preload より前に直 URL で出力される
- `img` も直 URL、HTML 中の `/_next/image` 参照は 0
- `/bg-image-1.webp` のリクエストは 1 回のみ（preload と img で二重取得なし）
- `onLoad` ゲートで出る greeting/ヘッダーが従来どおり表示される
- `/about` など他ページに preload は漏れない